### PR TITLE
fix: resolve 1.1.2 crashes

### DIFF
--- a/packages/android/app/src/main/AndroidManifest.xml
+++ b/packages/android/app/src/main/AndroidManifest.xml
@@ -72,8 +72,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-        <service android:name="org.eclipse.paho.android.service.MqttService" />
         <service
             android:name="com.amazonaws.mobileconnectors.s3.transferutility.TransferService"
             android:enabled="true" />

--- a/packages/android/app/src/main/java/io/literal/lib/AnnotationCollectionLib.java
+++ b/packages/android/app/src/main/java/io/literal/lib/AnnotationCollectionLib.java
@@ -1,5 +1,7 @@
 package io.literal.lib;
 
+import io.literal.repository.ErrorRepository;
+
 public class AnnotationCollectionLib {
     public static String makeId(String creatorUsername, String labelText) {
         try {
@@ -10,6 +12,7 @@ public class AnnotationCollectionLib {
                     idComponent
             );
         } catch (java.security.NoSuchAlgorithmException ex) {
+            ErrorRepository.captureException(ex);
             return null;
         }
     }

--- a/packages/android/app/src/main/java/io/literal/lib/AnnotationTargetLib.java
+++ b/packages/android/app/src/main/java/io/literal/lib/AnnotationTargetLib.java
@@ -1,0 +1,9 @@
+package io.literal.lib;
+
+import java.util.UUID;
+
+public class AnnotationTargetLib {
+    public static String makeId(String annotationId) {
+        return annotationId + "/targets/" + UUID.randomUUID().toString();
+    }
+}

--- a/packages/android/app/src/main/java/io/literal/ui/activity/MainActivity.java
+++ b/packages/android/app/src/main/java/io/literal/ui/activity/MainActivity.java
@@ -208,14 +208,19 @@ public class MainActivity extends SentryActivity {
             appWebViewPrimaryFragment = (AppWebView) getSupportFragmentManager().getFragment(savedInstanceState, APP_WEB_VIEW_PRIMARY_FRAGMENT_NAME);
             appWebViewBottomSheetFragment = (AppWebView) getSupportFragmentManager().getFragment(savedInstanceState, APP_WEB_VIEW_BOTTOM_SHEET_FRAGMENT_NAME);
             sourceWebViewBottomSheetFragment = (SourceWebView) getSupportFragmentManager().getFragment(savedInstanceState, SOURCE_WEB_VIEW_FRAGMENT_NAME);
-        } else {
+        }
+        if (appWebViewPrimaryFragment == null) {
             appWebViewPrimaryFragment = AppWebView.newInstance(initialUrl, APP_WEB_VIEW_PRIMARY_FRAGMENT_NAME);
+        }
+        if (sourceWebViewBottomSheetFragment == null) {
             sourceWebViewBottomSheetFragment = SourceWebView.newInstance(
                     null,
                     APP_WEB_VIEW_BOTTOM_SHEET_FRAGMENT_NAME,
                     APP_WEB_VIEW_PRIMARY_FRAGMENT_NAME,
                     R.drawable.arrow_drop_down_white
             );
+        }
+        if (appWebViewBottomSheetFragment == null) {
             appWebViewBottomSheetFragment = AppWebView.newInstance(
                     WebRoutes.creatorsIdWebview(authenticationViewModel.getUsername().getValue()),
                     APP_WEB_VIEW_BOTTOM_SHEET_FRAGMENT_NAME
@@ -321,9 +326,15 @@ public class MainActivity extends SentryActivity {
         super.onSaveInstanceState(outState);
 
         FragmentManager fragmentManager = getSupportFragmentManager();
-        fragmentManager.putFragment(outState, APP_WEB_VIEW_PRIMARY_FRAGMENT_NAME, appWebViewPrimaryFragment);
-        fragmentManager.putFragment(outState, SOURCE_WEB_VIEW_FRAGMENT_NAME, sourceWebViewBottomSheetFragment);
-        fragmentManager.putFragment(outState, APP_WEB_VIEW_BOTTOM_SHEET_FRAGMENT_NAME, appWebViewBottomSheetFragment);
+        if (appWebViewPrimaryFragment != null) {
+            fragmentManager.putFragment(outState, APP_WEB_VIEW_PRIMARY_FRAGMENT_NAME, appWebViewPrimaryFragment);
+        }
+        if (sourceWebViewBottomSheetFragment != null) {
+            fragmentManager.putFragment(outState, SOURCE_WEB_VIEW_FRAGMENT_NAME, sourceWebViewBottomSheetFragment);
+        }
+        if (appWebViewBottomSheetFragment != null) {
+            fragmentManager.putFragment(outState, APP_WEB_VIEW_BOTTOM_SHEET_FRAGMENT_NAME, appWebViewBottomSheetFragment);
+        }
     }
 
     @Override

--- a/packages/android/app/src/main/java/io/literal/ui/activity/MainActivity.java
+++ b/packages/android/app/src/main/java/io/literal/ui/activity/MainActivity.java
@@ -323,6 +323,7 @@ public class MainActivity extends SentryActivity {
         FragmentManager fragmentManager = getSupportFragmentManager();
         fragmentManager.putFragment(outState, APP_WEB_VIEW_PRIMARY_FRAGMENT_NAME, appWebViewPrimaryFragment);
         fragmentManager.putFragment(outState, SOURCE_WEB_VIEW_FRAGMENT_NAME, sourceWebViewBottomSheetFragment);
+        fragmentManager.putFragment(outState, APP_WEB_VIEW_BOTTOM_SHEET_FRAGMENT_NAME, appWebViewBottomSheetFragment);
     }
 
     @Override

--- a/packages/android/app/src/main/java/io/literal/ui/activity/ShareTargetHandler.java
+++ b/packages/android/app/src/main/java/io/literal/ui/activity/ShareTargetHandler.java
@@ -355,7 +355,7 @@ public class ShareTargetHandler extends SentryActivity {
 
     @Override
     public void onBackPressed() {
-        if (sourceWebViewFragment.getWebView().handleBackPressed()) {
+        if (sourceWebViewFragment != null && sourceWebViewFragment.getWebView().handleBackPressed()) {
             return;
         }
         super.onBackPressed();

--- a/packages/android/app/src/main/java/io/literal/viewmodel/AuthenticationViewModel.java
+++ b/packages/android/app/src/main/java/io/literal/viewmodel/AuthenticationViewModel.java
@@ -38,10 +38,10 @@ public class AuthenticationViewModel extends ViewModel {
 
     public MutableLiveData<Tokens> getTokens() {
         if (this.isSignedOut()) {
-            tokens.setValue(null);
+            tokens.postValue(null);
         } if (tokens.getValue() == null) {
             try {
-                tokens.setValue(AuthenticationRepository.getTokens());
+                tokens.postValue(AuthenticationRepository.getTokens());
             } catch (Exception e) {
                 ErrorRepository.captureException(e);
             }
@@ -51,10 +51,10 @@ public class AuthenticationViewModel extends ViewModel {
 
     public MutableLiveData<Map<String, String>> getUserAttributes() {
         if (this.isSignedOut()) {
-            userAttributes.setValue(null);
+            userAttributes.postValue(null);
         } else if (userAttributes.getValue() == null) {
             try {
-                userAttributes.setValue(AuthenticationRepository.getUserAttributes());
+                userAttributes.postValue(AuthenticationRepository.getUserAttributes());
             } catch (Exception e) {
                 ErrorRepository.captureException(e);
             }
@@ -65,18 +65,18 @@ public class AuthenticationViewModel extends ViewModel {
 
     public MutableLiveData<String> getUsername() {
         if (this.isSignedOut()) {
-            username.setValue(null);
+            username.postValue(null);
         } else if (username.getValue() == null) {
-            username.setValue(AuthenticationRepository.getUsername());
+            username.postValue(AuthenticationRepository.getUsername());
         }
         return username;
     }
 
     public MutableLiveData<String> getIdentityId() {
         if (this.isSignedOut()) {
-            identityId.setValue(null);
+            identityId.postValue(null);
         } else if (identityId.getValue() == null) {
-            identityId.setValue(AuthenticationRepository.getUsername());
+            identityId.postValue(AuthenticationRepository.getUsername());
         }
         return identityId;
     }
@@ -98,9 +98,7 @@ public class AuthenticationViewModel extends ViewModel {
             }
         });
 
-        AWSMobileClient.getInstance().addUserStateListener((userState) -> {
-            userStateDetails.postValue(userState);
-        });
+        AWSMobileClient.getInstance().addUserStateListener(userStateDetails::postValue);
     }
 
     public boolean isSignedOut() {


### PR DESCRIPTION
Resolves the following Sentry crashes observed in 1.1.2:

- [ANDROID-A](https://sentry.io/organizations/literal-io/issues/2318894502/?project=5700950&query=is%3Aunresolved)
- [ANDROID-Q](https://sentry.io/organizations/literal-io/issues/2328063755/?project=5700950&query=is%3Aunresolved)
- [ANDROID-K](https://sentry.io/organizations/literal-io/issues/2326005502/?project=5700950&query=is%3Aunresolved)
- [ANDROID-D](https://sentry.io/organizations/literal-io/issues/2320725305/?project=5700950&query=is%3Aunresolved)
- [ANDROID-E](https://sentry.io/organizations/literal-io/issues/2323356283/?project=5700950&query=is%3Aunresolved)
- [ANDROID-8](https://sentry.io/organizations/literal-io/issues/2316763185/?project=5700950&query=is%3Aunresolved)