### PR TITLE
feat: unify analytics

### DIFF
--- a/packages/android/app/build.gradle
+++ b/packages/android/app/build.gradle
@@ -89,6 +89,10 @@ dependencies {
 
     implementation 'io.sentry:sentry-android:4.3.0'
 
+    // Amplitude
+    implementation 'com.amplitude:android-sdk:2.25.2'
+    implementation 'com.squareup.okhttp3:okhttp:4.2.2'
+
     //
     // AWS
     //

--- a/packages/android/app/build.gradle
+++ b/packages/android/app/build.gradle
@@ -32,8 +32,8 @@ android {
         applicationId "io.literal"
         minSdkVersion 24
         targetSdkVersion 30
-        versionCode 12
-        versionName "1.1.4"
+        versionCode 13
+        versionName "1.1.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/packages/android/app/src/main/java/io/literal/lib/WebEvent.java
+++ b/packages/android/app/src/main/java/io/literal/lib/WebEvent.java
@@ -21,6 +21,8 @@ public class WebEvent {
     public static final String TYPE_DELETE_CACHE_ANNOTATION = "DELETE_CACHE_ANNOTATION";
     public static final String TYPE_CREATE_ANNOTATION_FROM_SOURCE = "CREATE_ANNOTATION_FROM_SOURCE";
     public static final String TYPE_ADD_CACHE_ANNOTATIONS = "ADD_CACHE_ANNOTATIONS";
+    public static final String TYPE_ANALYTICS_LOG_EVENT = "ANALYTICS_LOG_EVENT";
+    public static final String TYPE_ANALYTICS_SET_USER_ID = "ANALYTICS_SET_USER_ID";
 
     // Source WebView
     public static final String TYPE_VIEW_STATE_EDIT_ANNOTATION_TAGS = "VIEW_STATE_EDIT_ANNOTATION_TAGS";

--- a/packages/android/app/src/main/java/io/literal/repository/AnalyticsRepository.java
+++ b/packages/android/app/src/main/java/io/literal/repository/AnalyticsRepository.java
@@ -1,0 +1,29 @@
+package io.literal.repository;
+import android.app.Application;
+
+import com.amplitude.api.Amplitude;
+
+import org.json.JSONObject;
+
+public class AnalyticsRepository {
+
+    private static final String AMPLITUDE_API_KEY = "8f1701d791829e62f64f1c680c3f78d1";
+
+    public static final String TYPE_GRAPH_QL_OPERATION = "GRAPH_QL_OPERATION";
+    public static final String TYPE_ACTIVITY_START = "ACTIVITY_START";
+    public static final String TYPE_DISPATCHED_WEB_EVENT = "DISPATCHED_WEB_EVENT";
+    public static final String TYPE_RECEIVED_WEB_EVENT = "RECEIVED_WEB_EVENT";
+
+    public static void initialize(Application application) {
+        Amplitude.getInstance().initialize(application.getApplicationContext(), AMPLITUDE_API_KEY)
+                .enableForegroundTracking(application);
+    }
+
+    public static void logEvent(String type, JSONObject data) {
+        Amplitude.getInstance().logEvent(type, data);
+    }
+
+    public static void setUserId(String userId) {
+        Amplitude.getInstance().setUserId(userId);
+    }
+}

--- a/packages/android/app/src/main/java/io/literal/repository/AnnotationRepository.java
+++ b/packages/android/app/src/main/java/io/literal/repository/AnnotationRepository.java
@@ -9,10 +9,12 @@ import com.amazonaws.amplify.generated.graphql.GetAnnotationQuery;
 import com.amazonaws.amplify.generated.graphql.PatchAnnotationMutation;
 import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
 import com.apollographql.apollo.GraphQLCall;
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.List;
 
@@ -22,11 +24,24 @@ import io.literal.factory.AppSyncClientFactory;
 import io.literal.lib.Callback;
 import io.literal.lib.ManyCallback;
 import io.literal.model.Annotation;
+import type.CreateAnnotationInput;
 import type.DeleteAnnotationInput;
 import type.PatchAnnotationInput;
 
 public class AnnotationRepository {
     public static void patchAnnotationMutation(Context context, PatchAnnotationInput input, Callback<ApolloException, PatchAnnotationMutation.Data> callback) {
+        try {
+            JSONObject properties = new JSONObject();
+            JSONObject operationVariables = new JSONObject();
+            operationVariables.put("id", input.id());
+            properties.put("operationName", "PatchAnnotation");
+            properties.put("operationVariables", operationVariables);
+
+            AnalyticsRepository.logEvent(AnalyticsRepository.TYPE_GRAPH_QL_OPERATION, properties);
+        } catch (JSONException e) {
+            ErrorRepository.captureException(e);
+        }
+
         AppSyncClientFactory.getInstance(context)
                 .mutate(PatchAnnotationMutation.builder().input(input).build())
                 .enqueue(new GraphQLCall.Callback<PatchAnnotationMutation.Data>() {
@@ -50,6 +65,18 @@ public class AnnotationRepository {
     }
 
     public static void deleteAnnotationMutation(Context context, DeleteAnnotationInput input, Callback<ApolloException, DeleteAnnotationMutation.Data> callback) {
+        try {
+            JSONObject properties = new JSONObject();
+            JSONObject operationVariables = new JSONObject();
+            operationVariables.put("id", input.id());
+            properties.put("operationName", "DeleteAnnotation");
+            properties.put("operationVariables", operationVariables);
+
+            AnalyticsRepository.logEvent(AnalyticsRepository.TYPE_GRAPH_QL_OPERATION, properties);
+        } catch (JSONException e) {
+            ErrorRepository.captureException(e);
+        }
+
         AppSyncClientFactory.getInstance(context)
                 .mutate(DeleteAnnotationMutation.builder().input(input).build())
                 .enqueue(new GraphQLCall.Callback<DeleteAnnotationMutation.Data>() {
@@ -99,12 +126,25 @@ public class AnnotationRepository {
 
         for (int i = 0; i < annotations.length; i++) {
             Callback<ApolloException, CreateAnnotationMutation.Data> innerCallback = manyCallback.getCallback(i);
+            CreateAnnotationInput input = annotations[i].toCreateAnnotationInput();
+
+            try {
+                JSONObject properties = new JSONObject();
+                JSONObject operationVariables = new JSONObject();
+                operationVariables.put("id", input.id());
+                properties.put("operationName", "CreateAnnotation");
+                properties.put("operationVariables", operationVariables);
+
+                AnalyticsRepository.logEvent(AnalyticsRepository.TYPE_GRAPH_QL_OPERATION, properties);
+            } catch (JSONException e) {
+                ErrorRepository.captureException(e);
+            }
+
             appSyncClient
                     .mutate(
                             CreateAnnotationMutation.builder()
-                                    .input(annotations[i].toCreateAnnotationInput())
+                                    .input(input)
                                     .build()
-
                     )
                     .enqueue(new GraphQLCall.Callback<CreateAnnotationMutation.Data>() {
                         @Override

--- a/packages/android/app/src/main/java/io/literal/repository/NotificationRepository.java
+++ b/packages/android/app/src/main/java/io/literal/repository/NotificationRepository.java
@@ -129,6 +129,30 @@ public class NotificationRepository {
         notificationManager.notify(targetDomainMetadata.getUrl().getHost().hashCode(), builder.build());
     }
 
+    public static void sourceCreatedNotificationError(Context context, String creatorUsername, @NotNull DomainMetadata targetDomainMetadata) {
+        Intent intent = new Intent(context, MainActivity.class);
+        Uri uri = Uri.parse(WebRoutes.creatorsIdAnnotationCollectionId(
+                creatorUsername,
+                Constants.RECENT_ANNOTATION_COLLECTION_ID_COMPONENT
+        ));
+        intent.setData(uri);
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, context.getString(R.string.source_created_notification_channel_id))
+                .setSmallIcon(R.drawable.ic_stat_name)
+                .setColor(Color.BLACK)
+                .setContentTitle(context.getString(R.string.source_created_error_notification_title))
+                .setStyle(
+                        new NotificationCompat.BigTextStyle().bigText(context.getString(R.string.source_created_error_notification_description, targetDomainMetadata.getUrl().getHost()))
+                )
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setContentIntent(pendingIntent)
+                .setAutoCancel(true);
+        NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+
+        notificationManager.notify(targetDomainMetadata.getUrl().getHost().hashCode(), builder.build());
+    }
+
     public static void sourceCreatedNotificationStart(Context context, String creatorUsername, @NotNull DomainMetadata targetDomainMetadata, Pair<Integer, Integer> progress) {
         // FIXME: This should link to a source specific view, but none exists currently.
         Intent intent = new Intent(context, MainActivity.class);

--- a/packages/android/app/src/main/java/io/literal/service/AnnotationService.java
+++ b/packages/android/app/src/main/java/io/literal/service/AnnotationService.java
@@ -99,26 +99,35 @@ public class AnnotationService extends Service {
     private void handleCreateAnnotation(Annotation[] annotations, DomainMetadata domainMetadata, Callback<Exception, Void> onFinish) {
         Callback<Exception, Void> onFinishWithNotification = (e, _v) -> {
             if (e != null) {
-                try {
-                    Intent intent = new Intent();
-                    intent.setAction(ACTION_BROADCAST_CREATED_ANNOTATIONS);
-                    intent.putExtra(
-                            EXTRA_ANNOTATIONS,
-                            JsonArrayUtil.stringifyObjectArray(annotations, Annotation::toJson).toString()
-                    );
-                    LocalBroadcastManager.getInstance(getBaseContext()).sendBroadcast(intent);
-                } catch (JSONException ex) {
-                    ErrorRepository.captureException(ex);
-                }
+                NotificationRepository.sourceCreatedNotificationError(
+                        getBaseContext(),
+                        AuthenticationRepository.getUsername(),
+                        domainMetadata
+                );
+               onFinish.invoke(e, _v);
+               return;
             }
 
-            if (e == null && domainMetadata != null) {
+            try {
+                Intent intent = new Intent();
+                intent.setAction(ACTION_BROADCAST_CREATED_ANNOTATIONS);
+                intent.putExtra(
+                        EXTRA_ANNOTATIONS,
+                        JsonArrayUtil.stringifyObjectArray(annotations, Annotation::toJson).toString()
+                );
+                LocalBroadcastManager.getInstance(getBaseContext()).sendBroadcast(intent);
+            } catch (JSONException ex) {
+                ErrorRepository.captureException(ex);
+            }
+
+            if (domainMetadata != null) {
                 NotificationRepository.sourceCreatedNotificationComplete(
                         getBaseContext(),
                         AuthenticationRepository.getUsername(),
                         domainMetadata
                 );
             }
+
             onFinish.invoke(e, _v);
         };
 

--- a/packages/android/app/src/main/java/io/literal/ui/activity/InstrumentedActivity.java
+++ b/packages/android/app/src/main/java/io/literal/ui/activity/InstrumentedActivity.java
@@ -6,9 +6,10 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
 import io.literal.lib.Thunk;
+import io.literal.repository.AnalyticsRepository;
 import io.literal.repository.ErrorRepository;
 
-public class SentryActivity extends AppCompatActivity {
+public class InstrumentedActivity extends AppCompatActivity {
 
     private Thunk errorRepositoryCleanup;
 
@@ -16,6 +17,7 @@ public class SentryActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         errorRepositoryCleanup = ErrorRepository.initialize();
+        AnalyticsRepository.initialize(getApplication());
     }
 
     @Override

--- a/packages/android/app/src/main/java/io/literal/ui/activity/MainActivity.java
+++ b/packages/android/app/src/main/java/io/literal/ui/activity/MainActivity.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.Uri;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -15,7 +14,6 @@ import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -37,6 +35,7 @@ import io.literal.lib.JsonArrayUtil;
 import io.literal.lib.WebEvent;
 import io.literal.lib.WebRoutes;
 import io.literal.model.Annotation;
+import io.literal.repository.AnalyticsRepository;
 import io.literal.repository.ErrorRepository;
 import io.literal.repository.ToastRepository;
 import io.literal.service.AnnotationService;
@@ -47,9 +46,8 @@ import io.literal.ui.fragment.SourceWebView;
 import io.literal.viewmodel.AppWebViewViewModel;
 import io.literal.viewmodel.AuthenticationViewModel;
 import io.literal.viewmodel.SourceWebViewViewModel;
-import io.sentry.Sentry;
 
-public class MainActivity extends SentryActivity {
+public class MainActivity extends InstrumentedActivity {
 
     private static final String APP_WEB_VIEW_PRIMARY_FRAGMENT_NAME = "MAIN_ACTIVITY_APP_WEB_VIEW_PRIMARY_FRAGMENT";
     private static final String APP_WEB_VIEW_BOTTOM_SHEET_FRAGMENT_NAME = "MAIN_ACTIVITY_APP_WEB_VIEW_BOTTOM_SHEET_FRAGMENT";
@@ -104,6 +102,14 @@ public class MainActivity extends SentryActivity {
                 annotationCreatedBroadcastReceiver,
                 new IntentFilter(AnnotationService.ACTION_BROADCAST_CREATED_ANNOTATIONS)
         );
+
+        try {
+            JSONObject properties = new JSONObject();
+            properties.put("name", "MainActivity");
+            AnalyticsRepository.logEvent(AnalyticsRepository.TYPE_ACTIVITY_START, properties);
+        } catch (JSONException e) {
+            ErrorRepository.captureException(e);
+        }
     }
 
     @Override

--- a/packages/android/app/src/main/java/io/literal/ui/activity/ShareTargetHandler.java
+++ b/packages/android/app/src/main/java/io/literal/ui/activity/ShareTargetHandler.java
@@ -9,7 +9,6 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentContainerView;
 import androidx.lifecycle.ViewModelProvider;
@@ -20,6 +19,7 @@ import com.apollographql.apollo.api.Error;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.List;
 
@@ -30,7 +30,7 @@ import io.literal.lib.JsonArrayUtil;
 import io.literal.lib.WebEvent;
 import io.literal.lib.WebRoutes;
 import io.literal.model.Annotation;
-import io.literal.repository.AuthenticationRepository;
+import io.literal.repository.AnalyticsRepository;
 import io.literal.repository.ErrorRepository;
 import io.literal.repository.NotificationRepository;
 import io.literal.repository.ShareTargetHandlerRepository;
@@ -43,7 +43,7 @@ import io.literal.viewmodel.AppWebViewViewModel;
 import io.literal.viewmodel.AuthenticationViewModel;
 import io.literal.viewmodel.SourceWebViewViewModel;
 
-public class ShareTargetHandler extends SentryActivity {
+public class ShareTargetHandler extends InstrumentedActivity {
     private static final String APP_WEB_VIEW_FRAGMENT_NAME = "APP_WEB_VIEW_FRAGMENT";
     private static final String SOURCE_WEB_VIEW_FRAGMENT_NAME = "SOURCE_WEB_VIEW_FRAGMENT";
     public static final String RESULT_EXTRA_ANNOTATIONS = "RESULT_EXTRA_ANNOTATIONS";
@@ -101,6 +101,17 @@ public class ShareTargetHandler extends SentryActivity {
             }
         } else {
             handleSendNotSupported();
+        }
+
+        try {
+            JSONObject properties = new JSONObject();
+            properties.put("name", "ShareTargetHandler");
+            properties.put("action", action);
+            properties.put("type", type);
+            properties.put("extra", intent.getStringExtra(Intent.EXTRA_TEXT));
+            AnalyticsRepository.logEvent(AnalyticsRepository.TYPE_ACTIVITY_START, properties);
+        } catch (JSONException e) {
+            ErrorRepository.captureException(e);
         }
     }
 

--- a/packages/android/app/src/main/java/io/literal/ui/fragment/AppWebView.java
+++ b/packages/android/app/src/main/java/io/literal/ui/fragment/AppWebView.java
@@ -34,6 +34,7 @@ import io.literal.R;
 import io.literal.lib.ContentResolverLib;
 import io.literal.lib.FileActivityResultCallback;
 import io.literal.lib.WebEvent;
+import io.literal.repository.AnalyticsRepository;
 import io.literal.repository.ErrorRepository;
 import io.literal.ui.MainApplication;
 import io.literal.viewmodel.AppWebViewViewModel;
@@ -53,7 +54,6 @@ public class AppWebView extends Fragment {
     private AuthenticationViewModel authenticationViewModel;
     private io.literal.ui.view.AppWebView appWebView;
     private final WebEvent.Callback webEventCallback = new WebEvent.Callback() {
-
         private void handleSignIn(io.literal.ui.view.AppWebView view) {
             authenticationViewModel.signInGoogle(getActivity(), (e, _void) -> {
                 if (e != null) {
@@ -128,6 +128,23 @@ public class AppWebView extends Fragment {
                     return;
                 case WebEvent.TYPE_AUTH_GET_USER_INFO:
                     this.handleGetUserInfo(view);
+                    return;
+                case WebEvent.TYPE_ANALYTICS_LOG_EVENT:
+                    try {
+                        String eventType = event.getData().getString("type");
+                        JSONObject eventProperties = event.getData().getJSONObject("properties");
+                        AnalyticsRepository.logEvent(eventType, eventProperties);
+                    } catch (JSONException e) {
+                        ErrorRepository.captureException(e);
+                    }
+                    return;
+                case WebEvent.TYPE_ANALYTICS_SET_USER_ID:
+                    try {
+                        String userId = event.getData().getString("userId");
+                        AnalyticsRepository.setUserId(userId);
+                    } catch (JSONException e) {
+                        ErrorRepository.captureException(e);
+                    }
                     return;
             }
         }

--- a/packages/android/app/src/main/java/io/literal/ui/view/AppWebView.java
+++ b/packages/android/app/src/main/java/io/literal/ui/view/AppWebView.java
@@ -29,6 +29,8 @@ import io.literal.BuildConfig;
 import io.literal.lib.Constants;
 import io.literal.lib.WebEvent;
 import io.literal.lib.WebRoutes;
+import io.literal.repository.AnalyticsRepository;
+import io.literal.repository.ErrorRepository;
 
 public class AppWebView extends NestedScrollingChildWebView {
 
@@ -66,6 +68,15 @@ public class AppWebView extends NestedScrollingChildWebView {
                     ),
                     Uri.parse(WebRoutes.getWebHost())
             );
+
+            try {
+                JSONObject properties = new JSONObject();
+                properties.put("target", "AppWebView");
+                properties.put("event", webEvent.toJSON());
+                AnalyticsRepository.logEvent(AnalyticsRepository.TYPE_DISPATCHED_WEB_EVENT, properties);
+            } catch (JSONException e) {
+                ErrorRepository.captureException(e);
+            }
         }
     }
 
@@ -96,6 +107,11 @@ public class AppWebView extends NestedScrollingChildWebView {
                         if (webEventCallback != null) {
                             webEventCallback.onWebEvent(AppWebView.this, webEvent);
                         }
+
+                        JSONObject properties = new JSONObject();
+                        properties.put("target", "AppWebView");
+                        properties.put("event", json);
+                        AnalyticsRepository.logEvent(AnalyticsRepository.TYPE_RECEIVED_WEB_EVENT, properties);
                     } catch (JSONException ex) {
                         Log.e("Literal", "Error in onMessage", ex);
                     }

--- a/packages/android/app/src/main/java/io/literal/ui/view/SourceWebView.java
+++ b/packages/android/app/src/main/java/io/literal/ui/view/SourceWebView.java
@@ -53,6 +53,7 @@ import io.literal.lib.Callback;
 import io.literal.lib.Callback2;
 import io.literal.lib.ResultCallback;
 import io.literal.lib.WebEvent;
+import io.literal.repository.AnalyticsRepository;
 import io.literal.repository.ErrorRepository;
 import io.literal.repository.StorageRepository;
 
@@ -109,6 +110,14 @@ public class SourceWebView extends NestedScrollingChildWebView {
                     ),
                     Uri.parse("*")
             );
+            try {
+                JSONObject properties = new JSONObject();
+                properties.put("target", "SourceWebView");
+                properties.put("event", webEvent.toJSON());
+                AnalyticsRepository.logEvent(AnalyticsRepository.TYPE_DISPATCHED_WEB_EVENT, properties);
+            } catch (JSONException e) {
+                ErrorRepository.captureException(e);
+            }
         }
     }
 
@@ -137,8 +146,13 @@ public class SourceWebView extends NestedScrollingChildWebView {
                         if (webEventCallback != null) {
                             webEventCallback.invoke(null, SourceWebView.this, webEvent);
                         }
+
+                        JSONObject properties = new JSONObject();
+                        properties.put("target", "SourceWebView");
+                        properties.put("event", json);
+                        AnalyticsRepository.logEvent(AnalyticsRepository.TYPE_RECEIVED_WEB_EVENT, properties);
                     } catch (JSONException ex) {
-                        Log.e("Literal", "Error in onMessage", ex);
+                        ErrorRepository.captureException(ex);
                     }
                 }
             });

--- a/packages/android/app/src/main/res/values/strings.xml
+++ b/packages/android/app/src/main/res/values/strings.xml
@@ -24,4 +24,6 @@
     <string name="source_created_complete_notification_description"><i>%1$s</i> added to library.</string>
     <string name="source_created_start_notification_title">Creating Source</string>
     <string name="source_created_start_notification_description">Adding <i>%1$s</i> to library.</string>
+    <string name="source_created_error_notification_title">Error Creating Source</string>
+    <string name="source_created_error_notification_description">An error occurred while adding <i>%1$s</i> to your library. Please try to create your annotations again, and contact us if the issue persists.</string>
 </resources>

--- a/packages/web/src/Providers/Providers_Authentication.re
+++ b/packages/web/src/Providers/Providers_Authentication.re
@@ -36,7 +36,7 @@ let make = (~children) => {
             Js.Dict.fromList([("username", username->Js.Json.string)]),
           );
         let _ = Sentry.setContext("user", userData);
-        let _ = Amplitude.(getInstance()->setUserId(username));
+        let _ = Service_Analytics.setUserId(username);
         ();
       | _ => ()
       };


### PR DESCRIPTION
- Migrate to use the Android Amplitude SDK instead of the JS SDK when available (i.e. the web application is running within the WebView). This SDK is more efficient, as it batches event upload, and allows for instrumentation of native interactions (e.g. interactions with the Source Viewer.
- Fixes some bugs in AnnotationService:
  - Update the source created notification with an error state to enable for it to be dismissed if an error occurs while creating annotations from source.
  - Fix the state propagation so that existing instances of the application will update with the created annotations.