### PR TITLE
Fix: increase appsync timeout, remove duplicate logs

### DIFF
--- a/packages/android/app/build.gradle
+++ b/packages/android/app/build.gradle
@@ -32,8 +32,8 @@ android {
         applicationId "io.literal"
         minSdkVersion 24
         targetSdkVersion 30
-        versionCode 13
-        versionName "1.1.5"
+        versionCode 14
+        versionName "1.1.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/packages/android/app/src/main/java/io/literal/ui/view/AppWebView.java
+++ b/packages/android/app/src/main/java/io/literal/ui/view/AppWebView.java
@@ -108,10 +108,12 @@ public class AppWebView extends NestedScrollingChildWebView {
                             webEventCallback.onWebEvent(AppWebView.this, webEvent);
                         }
 
-                        JSONObject properties = new JSONObject();
-                        properties.put("target", "AppWebView");
-                        properties.put("event", json);
-                        AnalyticsRepository.logEvent(AnalyticsRepository.TYPE_RECEIVED_WEB_EVENT, properties);
+                        if (!webEvent.getType().equals(WebEvent.TYPE_ANALYTICS_LOG_EVENT) && !webEvent.getType().equals(WebEvent.TYPE_ANALYTICS_SET_USER_ID)) {
+                            JSONObject properties = new JSONObject();
+                            properties.put("target", "AppWebView");
+                            properties.put("event", json);
+                            AnalyticsRepository.logEvent(AnalyticsRepository.TYPE_RECEIVED_WEB_EVENT, properties);
+                        }
                     } catch (JSONException ex) {
                         Log.e("Literal", "Error in onMessage", ex);
                     }


### PR DESCRIPTION
## Fixed
- Prevent duplicate Amplitude events from being logged, as we were re-logging `AMPLITUDE_LOG_EVENTS` being delivered from the `AppWebView`.
- Increase AppSync client timeout in order to more reliably handle potentially long `CreateAnnotation` mutation latencies.