### PR TITLE
feat: improve annotation renderer

### DIFF
--- a/packages/android/app/src/foss/java/io/literal/repository/AnalyticsRepository.java
+++ b/packages/android/app/src/foss/java/io/literal/repository/AnalyticsRepository.java
@@ -15,6 +15,8 @@ public class AnalyticsRepository {
     public static final String TYPE_DISPATCH_SERVICE_INTENT = "DISPATCH_SERVICE_INTENT";
     public static final String TYPE_HANDLE_INTENT_START = "HANDLE_INTENT_START";
     public static final String TYPE_HANDLE_INTENT_COMPLETE = "HANDLE_INTENT_COMPLETE";
+    public static final String TYPE_ANNOTATION_RENDERER_INITIALIZED = "ANNOTATION_RENDERER_INITIALIZED";
+    public static final String TYPE_ANNOTATION_RENDERER_FAILED_TO_INITIALIZE = "ANNOTATION_RENDERER_FAILED_TO_INITIALIZE";
 
     public static void initialize(Application application) {
         Log.d("AnalyticsRepository", "initialize");

--- a/packages/android/app/src/full/java/io/literal/repository/AnalyticsRepository.java
+++ b/packages/android/app/src/full/java/io/literal/repository/AnalyticsRepository.java
@@ -1,12 +1,18 @@
 package io.literal.repository;
 
 import android.app.Application;
+import android.util.Log;
+
 import com.amplitude.api.Amplitude;
+
 import org.json.JSONObject;
+
+import io.literal.BuildConfig;
 
 public class AnalyticsRepository {
 
     private static final String AMPLITUDE_API_KEY = "8f1701d791829e62f64f1c680c3f78d1";
+
     public static final String TYPE_GRAPH_QL_OPERATION = "GRAPH_QL_OPERATION";
     public static final String TYPE_ACTIVITY_START = "ACTIVITY_START";
     public static final String TYPE_DISPATCHED_WEB_EVENT = "DISPATCHED_WEB_EVENT";
@@ -18,17 +24,29 @@ public class AnalyticsRepository {
     public static final String TYPE_ERROR_REPOSITORY_BREADCRUMB = "ERROR_REPOSITORY_BREADCRUMB";
     public static final String TYPE_ERROR_REPOSITORY_EXCEPTION = "ERROR_REPOSITORY_EXCEPTION";
     public static final String TYPE_ERROR_REPOSITORY_WARNING = "ERROR_REPOSITORY_WARNING";
+    public static final String TYPE_ANNOTATION_RENDERER_FAILED_TO_INITIALIZE = "ANNOTATION_RENDERER_FAILED_TO_INITIALIZE";
+    public static final String TYPE_ANNOTATION_RENDERER_INITIALIZED = "ANNOTATION_RENDERER_INITIALIZED";
 
     public static void initialize(Application application) {
         Amplitude.getInstance().initialize(application.getApplicationContext(), AMPLITUDE_API_KEY)
                 .enableForegroundTracking(application);
+
+        if (BuildConfig.DEBUG) {
+            Log.d("AnalyticsRepository", "initialize");
+        }
     }
 
     public static void logEvent(String type, JSONObject data) {
         Amplitude.getInstance().logEvent(type, data);
+        if (BuildConfig.DEBUG) {
+            Log.d("AnalyticsRepository", "logEvent: " + type + ", " + data.toString());
+        }
     }
 
     public static void setUserId(String userId) {
         Amplitude.getInstance().setUserId(userId);
+        if (BuildConfig.DEBUG) {
+            Log.d("AnalyticsRepository", "setUserId: " + userId);
+        }
     }
 }

--- a/packages/android/app/src/main/java/io/literal/lib/WebEvent.java
+++ b/packages/android/app/src/main/java/io/literal/lib/WebEvent.java
@@ -43,6 +43,7 @@ public class WebEvent {
     public static final String TYPE_EDIT_ANNOTATION = "EDIT_ANNOTATION";
     public static final String TYPE_SELECTION_CREATED = "SELECTION_CREATED";
     public static final String TYPE_ANNOTATION_RENDERER_INITIALIZED = "ANNOTATION_RENDERER_INITIALIZED";
+    public static final String TYPE_ANNOTATION_RENDERER_FAILED_TO_INITIALIZE = "ANNOTATION_RENDERER_FAILED_TO_INITIALIZE";
     public static final String TYPE_SELECTION_CHANGE = "SELECTION_CHANGE";
 
     private String type;

--- a/packages/android/app/src/main/java/io/literal/model/SourceInitializationStatus.java
+++ b/packages/android/app/src/main/java/io/literal/model/SourceInitializationStatus.java
@@ -1,0 +1,8 @@
+package io.literal.model;
+
+public enum SourceInitializationStatus {
+    UNINITIALIZED,
+    IN_PROGRESS,
+    FAILED,
+    INITIALIZED
+}

--- a/packages/android/app/src/main/java/io/literal/model/SourceJavaScriptConfig.java
+++ b/packages/android/app/src/main/java/io/literal/model/SourceJavaScriptConfig.java
@@ -1,0 +1,23 @@
+package io.literal.model;
+
+public class SourceJavaScriptConfig {
+    public enum Reason {
+        AUTOMATIC,
+        USER_TOGGLED
+    }
+    private final boolean isEnabled;
+    private final Reason reason;
+
+    public SourceJavaScriptConfig(boolean isEnabled, Reason reason) {
+        this.isEnabled = isEnabled;
+        this.reason = reason;
+    }
+
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+}

--- a/packages/android/app/src/main/java/io/literal/model/WebArchive.java
+++ b/packages/android/app/src/main/java/io/literal/model/WebArchive.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.util.Log;
 import android.webkit.WebResourceRequest;
 
 import org.apache.commons.io.IOUtils;
@@ -291,7 +292,6 @@ public class WebArchive {
     }
 
     public Optional<BodyPart> resolveWebResourceRequest(WebResourceRequest request, boolean isJavaScriptEnabled) {
-
         Optional<BodyPart> optionalBodyPart = Optional.empty();
 
         // If JavaScript is disabled, attempt to find the original index document using a custom header added

--- a/packages/android/app/src/main/java/io/literal/repository/ScriptRepository.java
+++ b/packages/android/app/src/main/java/io/literal/repository/ScriptRepository.java
@@ -1,6 +1,7 @@
 package io.literal.repository;
 
 import android.content.res.AssetManager;
+import android.util.Log;
 
 import org.apache.commons.io.IOUtils;
 import org.json.JSONArray;
@@ -10,6 +11,7 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.regex.Matcher;
 
 import io.literal.lib.JsonArrayUtil;
 import io.literal.model.Annotation;
@@ -70,7 +72,7 @@ public class ScriptRepository {
             return scriptOutput
                     .replaceAll(
                             "process\\.env\\.PARAM_ANNOTATIONS",
-                            paramAnnotations.substring(1, paramAnnotations.length() - 1)
+                            Matcher.quoteReplacement(paramAnnotations)
                     )
                     .replaceAll(
                             "process\\.env\\.PARAM_FOCUSED_ANNOTATION_ID",
@@ -80,8 +82,6 @@ public class ScriptRepository {
             ErrorRepository.captureException(e);
             return null;
         }
-
-
     }
 
     public static String getGetAnnotationBoundingBoxScript(AssetManager assetManager, JSONObject paramAnnotation) {
@@ -100,7 +100,7 @@ public class ScriptRepository {
         return scriptOutput
                 .replaceAll(
                         "process\\.env\\.PARAM_ANNOTATION",
-                        stringifiedParamAnnotation.substring(1, stringifiedParamAnnotation.length() - 1)
+                        Matcher.quoteReplacement(stringifiedParamAnnotation)
                 );
     }
 }

--- a/packages/android/app/src/main/java/io/literal/repository/WebArchiveRepository.java
+++ b/packages/android/app/src/main/java/io/literal/repository/WebArchiveRepository.java
@@ -82,7 +82,6 @@ public class WebArchiveRepository {
             RawField rawField = new RawField(FieldName.CONTENT_LOCATION, webResourceRequest.getUrl().toString());
             ContentLocationField contentLocationField = ContentLocationFieldImpl.PARSER.parse(rawField, DecodeMonitor.SILENT);
 
-            Log.i("createBodyPart", webResourceRequest.getUrl().toString());
 
             return Optional.of(
                     BodyPartBuilder.create()

--- a/packages/android/app/src/main/java/io/literal/service/AnnotationService.java
+++ b/packages/android/app/src/main/java/io/literal/service/AnnotationService.java
@@ -235,9 +235,7 @@ public class AnnotationService extends Service {
                         .collect(Collectors.toList())
         );
 
-        aggregateNotification.ifPresent((n) -> {
-            n.dispatch(context, user, intent);
-        });
+        aggregateNotification.ifPresent((n) -> n.dispatch(context, user, intent));
     }
 
     private void onUpdateAggregateNotificationProgress(Context context, CreateAnnotationIntent intent, Long bytesCurrent, Long bytesTotal) {

--- a/packages/android/app/src/main/java/io/literal/ui/activity/MainActivity.java
+++ b/packages/android/app/src/main/java/io/literal/ui/activity/MainActivity.java
@@ -16,6 +16,7 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
@@ -184,7 +185,15 @@ public class MainActivity extends InstrumentedActivity {
                                         .ifPresent((s) -> {
                                             if (displayBottomSheet) {
                                                 sourceWebViewBottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
-                                                appWebViewViewModelBottomSheet.setBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED);
+                                                sourceWebViewViewModelBottomSheet.getSourceHasFinishedInitializing().observe(this, new Observer<Boolean>() {
+                                                    @Override
+                                                    public void onChanged(Boolean sourceHasFinishedInitializing) {
+                                                        if (sourceHasFinishedInitializing) {
+                                                            sourceWebViewViewModelBottomSheet.getSourceHasFinishedInitializing().removeObserver(this);
+                                                            appWebViewViewModelBottomSheet.setBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED);
+                                                        }
+                                                    }
+                                                });
                                             }
                                         });
                             } catch (JSONException e) {

--- a/packages/android/app/src/main/java/io/literal/ui/activity/MainActivity.java
+++ b/packages/android/app/src/main/java/io/literal/ui/activity/MainActivity.java
@@ -235,9 +235,9 @@ public class MainActivity extends InstrumentedActivity {
         if (sourceWebViewBottomSheetFragment == null) {
             sourceWebViewBottomSheetFragment = SourceWebView.newInstance(
                     null,
+                    SourceWebView.SourceContext.READ_SOURCE,
                     APP_WEB_VIEW_BOTTOM_SHEET_FRAGMENT_NAME,
-                    APP_WEB_VIEW_PRIMARY_FRAGMENT_NAME,
-                    R.drawable.arrow_drop_down_white
+                    APP_WEB_VIEW_PRIMARY_FRAGMENT_NAME
             );
         }
         if (appWebViewBottomSheetFragment == null) {

--- a/packages/android/app/src/main/java/io/literal/ui/activity/ShareTargetHandler.java
+++ b/packages/android/app/src/main/java/io/literal/ui/activity/ShareTargetHandler.java
@@ -151,9 +151,9 @@ public class ShareTargetHandler extends InstrumentedActivity {
 
         sourceWebViewFragment = SourceWebView.newInstance(
                 sourceWebViewUri,
+                SourceWebView.SourceContext.CREATE_SOURCE,
                 null,
-                null,
-                R.drawable.done_white
+                null
         );
         sourceWebViewFragment.setOnToolbarPrimaryActionCallback((annotations, source) -> {
             this.handleCreateFromSourceDone(annotations);

--- a/packages/android/app/src/main/java/io/literal/ui/activity/ShareTargetHandler.java
+++ b/packages/android/app/src/main/java/io/literal/ui/activity/ShareTargetHandler.java
@@ -10,6 +10,7 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentContainerView;
+import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.amazonaws.amplify.generated.graphql.GetAnnotationQuery;
@@ -33,6 +34,7 @@ import io.literal.lib.WebEvent;
 import io.literal.lib.WebRoutes;
 import io.literal.model.Annotation;
 import io.literal.model.ErrorRepositoryLevel;
+import io.literal.model.SourceInitializationStatus;
 import io.literal.model.SourceWebViewAnnotation;
 import io.literal.model.StorageObject;
 import io.literal.model.User;
@@ -124,11 +126,15 @@ public class ShareTargetHandler extends InstrumentedActivity {
     private void installSourceWebView(String sourceWebViewUri, String appWebViewUri) {
         sourceWebViewViewModel = new ViewModelProvider(this).get(SourceWebViewViewModel.class);
 
-        sourceWebViewViewModel.getSourceHasFinishedInitializing().observe(this, hasFinishedInitializing -> {
-            ViewGroup splash = findViewById(R.id.share_target_handler_splash);
-            if (hasFinishedInitializing && splash.getVisibility() == View.VISIBLE) {
-                splash.setVisibility(View.INVISIBLE);
-                ToastRepository.show(this, R.string.toast_create_from_source);
+        sourceWebViewViewModel.getSourceInitializationStatus().observe(this, new Observer<SourceInitializationStatus>() {
+            @Override
+            public void onChanged(SourceInitializationStatus sourceInitializationStatus) {
+                ViewGroup splash = ShareTargetHandler.this.findViewById(R.id.share_target_handler_splash);
+                if (sourceInitializationStatus.equals(SourceInitializationStatus.INITIALIZED) && splash.getVisibility() == View.VISIBLE) {
+                    splash.setVisibility(View.INVISIBLE);
+                    ToastRepository.show(ShareTargetHandler.this, R.string.toast_create_from_source);
+                    sourceWebViewViewModel.getSourceInitializationStatus().removeObserver(this);
+                }
             }
         });
 

--- a/packages/android/app/src/main/java/io/literal/ui/fragment/SourceWebView.java
+++ b/packages/android/app/src/main/java/io/literal/ui/fragment/SourceWebView.java
@@ -307,12 +307,15 @@ public class SourceWebView extends Fragment {
                     break;
                 case WebEvent.TYPE_ANNOTATION_RENDERER_INITIALIZED:
                     sourceWebViewViewModel.setSourceHasFinishedInitializing(true);
+                    if (!this.sourceWebViewViewModel.getSourceJavascriptEnabled().getValue()) {
+                        ToastRepository.show(getActivity(), R.string.toast_javascript_disabled, ToastRepository.STYLE_DARK_ACCENT);
+                    }
                     break;
                 case WebEvent.TYPE_ANNOTATION_RENDERER_FAILED_TO_INITIALIZE:
                     if (this.sourceWebViewViewModel.getSourceJavascriptEnabled().getValue()) {
                         this.sourceWebViewViewModel.setSourceJavascriptEnabled(false);
                     } else {
-                        // FIXME: failed to initialize annotation with javascript disabled, show error
+                        ToastRepository.show(getActivity(), R.string.toast_annotation_renderer_failed_to_initialize, ToastRepository.STYLE_DARK_ACCENT);
                     }
                     break;
                 case WebEvent.TYPE_SELECTION_CHANGE:
@@ -476,8 +479,6 @@ public class SourceWebView extends Fragment {
         if (!annotation.getFocusStatus().equals(SourceWebViewAnnotation.FocusStatus.FOCUSED)) {
             sourceWebViewViewModel.setFocusedAnnotationId(annotation.getAnnotation().getId());
         }
-
-        bottomSheetAppWebViewViewModel.setBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED);
 
         if (editAnnotationActionMode != null) {
             webView.finishEditAnnotationActionMode(editAnnotationActionMode);

--- a/packages/android/app/src/main/java/io/literal/ui/fragment/SourceWebView.java
+++ b/packages/android/app/src/main/java/io/literal/ui/fragment/SourceWebView.java
@@ -307,7 +307,12 @@ public class SourceWebView extends Fragment {
                     break;
                 case WebEvent.TYPE_ANNOTATION_RENDERER_INITIALIZED:
                     sourceWebViewViewModel.setSourceHasFinishedInitializing(true);
-                    if (!this.sourceWebViewViewModel.getSourceJavascriptEnabled().getValue()) {
+                    boolean javascriptEnabled = Optional.ofNullable(this.sourceWebViewViewModel).map((vm) -> vm.getSourceJavascriptEnabled().getValue()).orElse(true);
+                    boolean sourceVisible = Optional.ofNullable(this.primaryAppWebViewViewModel)
+                            .flatMap((vm) -> Optional.ofNullable(vm.getBottomSheetState().getValue()))
+                            .map((s) -> s.equals(BottomSheetBehavior.STATE_EXPANDED))
+                            .orElse(false);
+                    if (!javascriptEnabled && sourceVisible) {
                         ToastRepository.show(getActivity(), R.string.toast_javascript_disabled, ToastRepository.STYLE_DARK_ACCENT);
                     }
                     break;
@@ -353,7 +358,6 @@ public class SourceWebView extends Fragment {
 
             bottomSheetAppWebViewViewModel.clearReceivedWebEvents();
         });
-
         bottomSheetAppWebViewViewModel.getBottomSheetState().observe(requireActivity(), (bottomSheetState) -> {
             switch (bottomSheetState) {
                 case BottomSheetBehavior.STATE_COLLAPSED:

--- a/packages/android/app/src/main/java/io/literal/ui/view/SourceWebView/Client.java
+++ b/packages/android/app/src/main/java/io/literal/ui/view/SourceWebView/Client.java
@@ -43,7 +43,6 @@ public class Client extends WebViewClient {
     private boolean shouldClearHistoryOnPageFinished = false;
     private boolean hasInjectedAnnotationRendererScript = false;
 
-    // WebView as param, get source?
     public Client(
             @NonNull Context context,
             @NonNull Source source,
@@ -79,7 +78,7 @@ public class Client extends WebViewClient {
         try {
             webArchive.open(context, user).get();
 
-            Optional<BodyPart> optionalBodyPart = webArchive.resolveWebResourceRequest(request);
+            Optional<BodyPart> optionalBodyPart = webArchive.resolveWebResourceRequest(request, source.getJavaScriptEnabled());
 
             Optional<WebResourceResponse> response = optionalBodyPart.flatMap((bodyPart) -> {
                 try {
@@ -186,6 +185,10 @@ public class Client extends WebViewClient {
                 onSourceChanged.invoke(new Source(newSourceURI, Optional.empty()));
             }
         });
+    }
+
+    public void setHasInjectedAnnotationRendererScript(boolean hasInjectedAnnotationRendererScript) {
+        this.hasInjectedAnnotationRendererScript = hasInjectedAnnotationRendererScript;
     }
 
     public void setShouldClearHistoryOnPageFinished(boolean shouldClearHistoryOnPageFinished) {

--- a/packages/android/app/src/main/java/io/literal/ui/view/SourceWebView/Source.java
+++ b/packages/android/app/src/main/java/io/literal/ui/view/SourceWebView/Source.java
@@ -41,6 +41,7 @@ public class Source {
     // Metadata
     private Optional<Bitmap> favicon;
     private final ArrayList<WebResourceRequest> pageWebResourceRequests;
+    private boolean javaScriptEnabled;
 
     public Source(@NotNull WebArchive webArchive, Optional<URI> displayURI) {
         this.webArchive = Optional.of(webArchive);
@@ -49,6 +50,7 @@ public class Source {
         this.favicon = Optional.empty();
         this.type = Type.WEB_ARCHIVE;
         this.pageWebResourceRequests = new ArrayList<>();
+        this.javaScriptEnabled = true;
     }
 
     public Source(@NotNull URI uri, Optional<URI> displayURI) {
@@ -58,6 +60,7 @@ public class Source {
         this.favicon = Optional.empty();
         this.type = Type.EXTERNAL_SOURCE;
         this.pageWebResourceRequests = new ArrayList<>();
+        this.javaScriptEnabled = true;
     }
 
     public URI getDisplayURI() {
@@ -147,6 +150,14 @@ public class Source {
 
     public void setFavicon(Optional<Bitmap> favicon) {
         this.favicon = favicon;
+    }
+
+    public void setJavaScriptEnabled(boolean javaScriptEnabled) {
+        this.javaScriptEnabled = javaScriptEnabled;
+    }
+
+    public boolean getJavaScriptEnabled() {
+        return this.javaScriptEnabled;
     }
 
     public enum Type {

--- a/packages/android/app/src/main/java/io/literal/ui/view/SourceWebView/SourceWebView.java
+++ b/packages/android/app/src/main/java/io/literal/ui/view/SourceWebView/SourceWebView.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import android.view.ActionMode;
 import android.view.MotionEvent;
 import android.webkit.WebChromeClient;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
@@ -16,6 +17,7 @@ import androidx.core.view.MotionEventCompat;
 import androidx.core.view.NestedScrollingChild;
 import androidx.core.view.NestedScrollingChildHelper;
 import androidx.core.view.ViewCompat;
+import androidx.webkit.ServiceWorkerWebSettingsCompat;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/packages/android/app/src/main/java/io/literal/viewmodel/SourceWebViewViewModel.java
+++ b/packages/android/app/src/main/java/io/literal/viewmodel/SourceWebViewViewModel.java
@@ -2,10 +2,13 @@ package io.literal.viewmodel;
 
 import android.content.Context;
 import android.util.Log;
+import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
+
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
 import org.json.JSONObject;
 
@@ -29,6 +32,7 @@ import io.literal.model.Body;
 import io.literal.model.Format;
 import io.literal.model.Language;
 import io.literal.model.Motivation;
+import io.literal.model.SourceJavaScriptConfig;
 import io.literal.model.SourceWebViewAnnotation;
 import io.literal.model.Target;
 import io.literal.model.TextDirection;
@@ -42,11 +46,12 @@ import io.literal.ui.view.SourceWebView.SourceWebView;
 
 public class SourceWebViewViewModel extends ViewModel {
     private final MutableLiveData<Boolean> sourceHasFinishedInitializing = new MutableLiveData<>(false);
-    private final MutableLiveData<Boolean> sourceJavascriptEnabled = new MutableLiveData<>(true);
+    private final MutableLiveData<SourceJavaScriptConfig> sourceJavaScriptConfig = new MutableLiveData<>(new SourceJavaScriptConfig(true, SourceJavaScriptConfig.Reason.AUTOMATIC));
+    private final MutableLiveData<SourceWebViewAnnotation[]> annotationsLiveData = new MutableLiveData<>(new SourceWebViewAnnotation[0]);
 
     private final HashMap<String, SourceWebViewAnnotation> annotations = new HashMap<>();
     private final HashMap<String, CompletableFuture<Annotation>> compiledAnnotations = new HashMap<>();
-    private final MutableLiveData<SourceWebViewAnnotation[]> annotationsLiveData = new MutableLiveData<>(new SourceWebViewAnnotation[0]);
+    private Optional<BottomSheetBehavior<FrameLayout>> bottomSheetBehavior = Optional.empty();
 
     public MutableLiveData<SourceWebViewAnnotation[]> getAnnotations() {
         return annotationsLiveData;
@@ -60,12 +65,12 @@ public class SourceWebViewViewModel extends ViewModel {
         this.sourceHasFinishedInitializing.setValue(sourceHasFinishedInitializing);
     }
 
-    public MutableLiveData<Boolean> getSourceJavascriptEnabled() {
-        return sourceJavascriptEnabled;
+    public MutableLiveData<SourceJavaScriptConfig> getSourceJavaScriptConfig() {
+        return sourceJavaScriptConfig;
     }
 
-    public void setSourceJavascriptEnabled(boolean sourceJavascriptEnabled) {
-        this.sourceJavascriptEnabled.setValue(sourceJavascriptEnabled);
+    public void setSourceJavaScriptConfig(SourceJavaScriptConfig sourceJavaScriptConfig) {
+        this.sourceJavaScriptConfig.setValue(sourceJavaScriptConfig);
     }
 
     public void reset() {
@@ -73,6 +78,7 @@ public class SourceWebViewViewModel extends ViewModel {
         this.compiledAnnotations.clear();
         this.sourceHasFinishedInitializing.setValue(false);
         this.annotationsLiveData.setValue(new SourceWebViewAnnotation[0]);
+        this.sourceJavaScriptConfig.setValue(new SourceJavaScriptConfig(true, SourceJavaScriptConfig.Reason.AUTOMATIC));
     }
 
     public Optional<SourceWebViewAnnotation> getFocusedAnnotation() {
@@ -251,5 +257,13 @@ public class SourceWebViewViewModel extends ViewModel {
 
     public Optional<CompletableFuture<Annotation>> getCompiledAnnotation(String annotationId) {
         return Optional.ofNullable(compiledAnnotations.get(annotationId));
+    }
+
+    public Optional<BottomSheetBehavior<FrameLayout>> getBottomSheetBehavior() {
+        return this.bottomSheetBehavior;
+    }
+
+    public void setBottomSheetBehavior(Optional<BottomSheetBehavior<FrameLayout>> bottomSheetBehavior) {
+        this.bottomSheetBehavior = bottomSheetBehavior;
     }
 }

--- a/packages/android/app/src/main/java/io/literal/viewmodel/SourceWebViewViewModel.java
+++ b/packages/android/app/src/main/java/io/literal/viewmodel/SourceWebViewViewModel.java
@@ -32,6 +32,7 @@ import io.literal.model.Body;
 import io.literal.model.Format;
 import io.literal.model.Language;
 import io.literal.model.Motivation;
+import io.literal.model.SourceInitializationStatus;
 import io.literal.model.SourceJavaScriptConfig;
 import io.literal.model.SourceWebViewAnnotation;
 import io.literal.model.Target;
@@ -45,7 +46,7 @@ import io.literal.ui.view.SourceWebView.Source;
 import io.literal.ui.view.SourceWebView.SourceWebView;
 
 public class SourceWebViewViewModel extends ViewModel {
-    private final MutableLiveData<Boolean> sourceHasFinishedInitializing = new MutableLiveData<>(false);
+    private final MutableLiveData<SourceInitializationStatus> sourceInitializationStatus = new MutableLiveData<>(SourceInitializationStatus.UNINITIALIZED);
     private final MutableLiveData<SourceJavaScriptConfig> sourceJavaScriptConfig = new MutableLiveData<>(new SourceJavaScriptConfig(true, SourceJavaScriptConfig.Reason.AUTOMATIC));
     private final MutableLiveData<SourceWebViewAnnotation[]> annotationsLiveData = new MutableLiveData<>(new SourceWebViewAnnotation[0]);
 
@@ -57,12 +58,12 @@ public class SourceWebViewViewModel extends ViewModel {
         return annotationsLiveData;
     }
 
-    public MutableLiveData<Boolean> getSourceHasFinishedInitializing() {
-        return sourceHasFinishedInitializing;
+    public MutableLiveData<SourceInitializationStatus> getSourceInitializationStatus() {
+        return sourceInitializationStatus;
     }
 
-    public void setSourceHasFinishedInitializing(boolean sourceHasFinishedInitializing) {
-        this.sourceHasFinishedInitializing.setValue(sourceHasFinishedInitializing);
+    public void setSourceInitializationStatus(@NonNull SourceInitializationStatus sourceInitializationStatus) {
+        this.sourceInitializationStatus.setValue(sourceInitializationStatus);
     }
 
     public MutableLiveData<SourceJavaScriptConfig> getSourceJavaScriptConfig() {
@@ -76,7 +77,7 @@ public class SourceWebViewViewModel extends ViewModel {
     public void reset() {
         this.annotations.clear();
         this.compiledAnnotations.clear();
-        this.sourceHasFinishedInitializing.setValue(false);
+        this.sourceInitializationStatus.setValue(SourceInitializationStatus.UNINITIALIZED);
         this.annotationsLiveData.setValue(new SourceWebViewAnnotation[0]);
         this.sourceJavaScriptConfig.setValue(new SourceJavaScriptConfig(true, SourceJavaScriptConfig.Reason.AUTOMATIC));
     }

--- a/packages/android/app/src/main/java/io/literal/viewmodel/SourceWebViewViewModel.java
+++ b/packages/android/app/src/main/java/io/literal/viewmodel/SourceWebViewViewModel.java
@@ -42,6 +42,7 @@ import io.literal.ui.view.SourceWebView.SourceWebView;
 
 public class SourceWebViewViewModel extends ViewModel {
     private final MutableLiveData<Boolean> sourceHasFinishedInitializing = new MutableLiveData<>(false);
+    private final MutableLiveData<Boolean> sourceJavascriptEnabled = new MutableLiveData<>(true);
 
     private final HashMap<String, SourceWebViewAnnotation> annotations = new HashMap<>();
     private final HashMap<String, CompletableFuture<Annotation>> compiledAnnotations = new HashMap<>();
@@ -57,6 +58,14 @@ public class SourceWebViewViewModel extends ViewModel {
 
     public void setSourceHasFinishedInitializing(boolean sourceHasFinishedInitializing) {
         this.sourceHasFinishedInitializing.setValue(sourceHasFinishedInitializing);
+    }
+
+    public MutableLiveData<Boolean> getSourceJavascriptEnabled() {
+        return sourceJavascriptEnabled;
+    }
+
+    public void setSourceJavascriptEnabled(boolean sourceJavascriptEnabled) {
+        this.sourceJavascriptEnabled.setValue(sourceJavascriptEnabled);
     }
 
     public void reset() {

--- a/packages/android/app/src/main/res/drawable/arrow_drop_down_white.xml
+++ b/packages/android/app/src/main/res/drawable/arrow_drop_down_white.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="36dp"
-    android:height="36dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-  <path
-      android:pathData="M7,10l5,5 5,-5z"
-      android:fillColor="#80ffffff"/>
-</vector>

--- a/packages/android/app/src/main/res/drawable/ic_baseline_arrow_drop_down_24.xml
+++ b/packages/android/app/src/main/res/drawable/ic_baseline_arrow_drop_down_24.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.92" android:height="24dp"
+    android:tint="#FFFFFF" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M7,10l5,5 5,-5z"/>
+</vector>

--- a/packages/android/app/src/main/res/drawable/ic_baseline_build_24.xml
+++ b/packages/android/app/src/main/res/drawable/ic_baseline_build_24.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.92" android:height="24dp"
+    android:tint="#FFFFFF" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M22.7,19l-9.1,-9.1c0.9,-2.3 0.4,-5 -1.5,-6.9 -2,-2 -5,-2.4 -7.4,-1.3L9,6 6,9 1.6,4.7C0.4,7.1 0.9,10.1 2.9,12.1c1.9,1.9 4.6,2.4 6.9,1.5l9.1,9.1c0.4,0.4 1,0.4 1.4,0l2.3,-2.3c0.5,-0.4 0.5,-1.1 0.1,-1.4z"/>
+</vector>

--- a/packages/android/app/src/main/res/drawable/ic_baseline_keyboard_arrow_down_24.xml
+++ b/packages/android/app/src/main/res/drawable/ic_baseline_keyboard_arrow_down_24.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.92" android:height="24dp"
+    android:tint="#FFFFFF" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M7.41,8.59L12,13.17l4.59,-4.58L18,10l-6,6 -6,-6 1.41,-1.41z"/>
+</vector>

--- a/packages/android/app/src/main/res/drawable/ic_baseline_more_vert_24.xml
+++ b/packages/android/app/src/main/res/drawable/ic_baseline_more_vert_24.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.92" android:height="24dp"
+    android:tint="#FFFFFF" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+</vector>

--- a/packages/android/app/src/main/res/layout/fragment_source_web_view.xml
+++ b/packages/android/app/src/main/res/layout/fragment_source_web_view.xml
@@ -23,6 +23,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="48dp"
                 android:background="@color/colorDarkAccent"
+                app:theme="@style/ThemeOverlay.AppCompat.SourceWebViewToolbar"
+                app:popupTheme="@style/ThemeOverlay.AppCompat.SourceWebViewToolbarPopup"
                 app:elevation="6dp"
                 app:titleTextAppearance="@style/SourceWebViewTitleTextAppearance"
                 app:titleMarginStart="32dp"/>

--- a/packages/android/app/src/main/res/menu/source_webview_toolbar_create.xml
+++ b/packages/android/app/src/main/res/menu/source_webview_toolbar_create.xml
@@ -2,7 +2,8 @@
 <menu xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/primary"
-        android:title="@string/done"
+        android:id="@+id/create_annotations"
+        android:title="@string/toolbar_create_annotations"
+        android:icon="@drawable/done_white"
         app:showAsAction="ifRoom" />
 </menu>

--- a/packages/android/app/src/main/res/menu/source_webview_toolbar_read.xml
+++ b/packages/android/app/src/main/res/menu/source_webview_toolbar_read.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/loading_indicator"
+        app:actionLayout="@layout/webview_toolbar_indeterminate_progress"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/close_source"
+        android:icon="@drawable/ic_baseline_keyboard_arrow_down_24"
+        android:title="@string/toolbar_close_source"
+        app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/javascript_enabled"
+        android:checkable="true"
+        android:checked="true"
+        android:icon="@drawable/ic_baseline_build_24"
+        android:title="@string/toolbar_javascript_enabled"
+        app:showAsAction="never" />
+</menu>

--- a/packages/android/app/src/main/res/menu/source_webview_toolbar_read.xml
+++ b/packages/android/app/src/main/res/menu/source_webview_toolbar_read.xml
@@ -12,10 +12,8 @@
         android:title="@string/toolbar_close_source"
         app:showAsAction="ifRoom" />
     <item
-        android:id="@+id/javascript_enabled"
-        android:checkable="true"
-        android:checked="true"
+        android:id="@+id/javascript_toggle"
         android:icon="@drawable/ic_baseline_build_24"
-        android:title="@string/toolbar_javascript_enabled"
+        android:title="@string/toolbar_enable_javascript"
         app:showAsAction="never" />
 </menu>

--- a/packages/android/app/src/main/res/values/colors.xml
+++ b/packages/android/app/src/main/res/values/colors.xml
@@ -5,4 +5,5 @@
     <color name="colorDarkAccent">#1A1A1A</color>
     <color name="colorAccent">#1A1A1A</color>
     <color name="colorTextLightPrimary">#F2FFFFFF</color>
+    <color name="colorTextLightSecondary">#99FFFFFF</color>
 </resources>

--- a/packages/android/app/src/main/res/values/strings.xml
+++ b/packages/android/app/src/main/res/values/strings.xml
@@ -4,9 +4,13 @@
     <string name="annotate">Annotate</string>
     <string name="edit">Edit</string>
     <string name="remove">Remove</string>
-    <string name="done">Done</string>
     <string name="commit">Commit</string>
     <string name="cancel">Cancel</string>
+
+    <string name="toolbar_create_annotations">Create Annotations</string>
+    <string name="toolbar_view_more_options">View More Options</string>
+    <string name="toolbar_close_source">Close Source</string>
+    <string name="toolbar_javascript_enabled">JavaScript Enabled</string>
 
     <string name="toast_create_from_source">Highlight text to annotate</string>
     <string name="toast_annotation_created">Annotation created</string>

--- a/packages/android/app/src/main/res/values/strings.xml
+++ b/packages/android/app/src/main/res/values/strings.xml
@@ -16,6 +16,8 @@
     <string name="toast_annotation_created">Annotation created</string>
     <string name="toast_annotations_created">Annotations created</string>
     <string name="toast_error_annotation_created">Unable to capture annotation, try again.</string>
+    <string name="toast_javascript_disabled">JavaScript disabled, some source functionality may not work.</string>
+    <string name="toast_annotation_renderer_failed_to_initialize">There was an issue rendering this annotation.</string>
 
     <string name="annotation_created_notification_channel_id">ANNOTATION_CREATED</string>
     <string name="annotation_created_notification_channel_name">Annotation Created</string>

--- a/packages/android/app/src/main/res/values/strings.xml
+++ b/packages/android/app/src/main/res/values/strings.xml
@@ -10,7 +10,8 @@
     <string name="toolbar_create_annotations">Create Annotations</string>
     <string name="toolbar_view_more_options">View More Options</string>
     <string name="toolbar_close_source">Close Source</string>
-    <string name="toolbar_javascript_enabled">JavaScript Enabled</string>
+    <string name="toolbar_enable_javascript">Enable JavaScript</string>
+    <string name="toolbar_disable_javascript">Disable JavaScript</string>
 
     <string name="toast_create_from_source">Highlight text to annotate</string>
     <string name="toast_annotation_created">Annotation created</string>

--- a/packages/android/app/src/main/res/values/styles.xml
+++ b/packages/android/app/src/main/res/values/styles.xml
@@ -14,7 +14,6 @@
         <item name="android:spotShadowAlpha">0.5</item>
         <item name="fontFamily">@font/roboto_mono</item>
         <item name="actionModeStyle">@style/ActionModeStyle</item>
-        <item name="popupMenuStyle">@style/ActionModeStyle</item>
     </style>
 
     <style name="AppWebViewTheme" parent="AppTheme">
@@ -27,6 +26,7 @@
         <item name="android:textSize">14sp</item>
         <item name="android:textColor">@color/colorTextLightPrimary</item>
         <item name="android:fontFamily">@font/roboto_mono_italic</item>
+        <item name="android:fontStyle">italic</item>
     </style>
 
     <style name="BottomSheetWithKeyboard" parent="@style/Widget.MaterialComponents.BottomSheet">
@@ -46,19 +46,48 @@
         <item name="android:fontFamily">@font/roboto_mono</item>
     </style>
 
+    <style name="PopupMenuTextAppearance">
+        <item name="android:textSize">14sp</item>
+        <item name="android:textColor">@color/colorTextLightPrimary</item>
+        <item name="android:fontFamily">@font/roboto_mono</item>
+    </style>
+
     <style name="ActionModeStyle">
         <item name="background">@color/colorPrimary</item>
         <item name="titleTextStyle">@style/ActionMenuTextAppearance</item>
         <item name="subtitleTextStyle">@style/ActionMenuTextAppearance</item>
         <item name="android:textSize">14sp</item>
         <item name="android:textColor">@color/colorTextLightPrimary</item>
+        <item name="android:textColorSecondary">@color/colorTextLightSecondary</item>
         <item name="android:fontFamily">@font/roboto_mono</item>
+        <item name="colorAccent">@color/colorTextLightSecondary</item>
+    </style>
+
+    <style name="ThemeOverlay.AppCompat.SourceWebViewToolbar">
+        <item name="colorPrimary">@color/colorTextLightPrimary</item>
+        <item name="colorAccent">@color/colorTextLightSecondary</item>
+        <item name="colorControlHighlight">@color/colorTextLightSecondary</item>
+        <item name="fontFamily">@font/roboto_mono_italic</item>
+        <item name="fontStyle">italic</item>
+    </style>
+
+    <style name="ThemeOverlay.AppCompat.SourceWebViewToolbarPopup">
+        <item name="colorPrimary">@color/colorTextLightPrimary</item>
+        <item name="colorAccent">@color/colorTextLightSecondary</item>
+        <item name="colorControlHighlight">@color/colorTextLightSecondary</item>
+        <item name="android:textSize">12sp</item>
+        <item name="fontFamily">@font/roboto_mono</item>
+        <item name="fontStyle">normal</item>
     </style>
 
     <style name="LightActionMenuTextAppearance">
         <item name="android:textSize">14sp</item>
         <item name="android:textColor">@color/colorPrimaryDark</item>
         <item name="android:fontFamily">@font/roboto_mono</item>
+    </style>
+
+    <style name="ToolbarPopupMenuText">
+        <item name="android:layout_marginHorizontal">16dp</item>
     </style>
 
     <style name="LightActionModeStyle">

--- a/packages/android/app/src/main/res/values/styles.xml
+++ b/packages/android/app/src/main/res/values/styles.xml
@@ -75,7 +75,7 @@
         <item name="colorPrimary">@color/colorTextLightPrimary</item>
         <item name="colorAccent">@color/colorTextLightSecondary</item>
         <item name="colorControlHighlight">@color/colorTextLightSecondary</item>
-        <item name="android:textSize">12sp</item>
+        <item name="android:textSize">14sp</item>
         <item name="fontFamily">@font/roboto_mono</item>
         <item name="fontStyle">normal</item>
     </style>

--- a/packages/android/source-webview-scripts/annotation-renderer/index.mjs
+++ b/packages/android/source-webview-scripts/annotation-renderer/index.mjs
@@ -55,21 +55,27 @@ export default () =>
 
     if (storageGet("hasInitialized")) {
       console.log(
-        "[Literal] Expeted uninitialized DOM, but found it already initialized: noop-ing."
+        "[Literal] Expected uninitialized DOM, but found it already initialized: noop-ing."
       );
       return;
     }
     storageSet("hasInitialized", true);
 
-    await renderer.render(ANNOTATIONS);
-    renderer.onInitialAnnotationsRendered();
-    annotationFocusManager.onAnnotationsRendered({
-      annotations: ANNOTATIONS,
-      focusedAnnotationId: FOCUSED_ANNOTATION_ID,
-      initialRender: true,
-    });
+    try {
+      await renderer.render(ANNOTATIONS);
+      renderer.onInitialAnnotationsRendered();
+      annotationFocusManager.onAnnotationsRendered({
+        annotations: ANNOTATIONS,
+        focusedAnnotationId: FOCUSED_ANNOTATION_ID,
+        initialRender: true,
+      });
 
-    messenger.postMessage({
-      type: "ANNOTATION_RENDERER_INITIALIZED",
-    });
+      messenger.postMessage({
+        type: "ANNOTATION_RENDERER_INITIALIZED",
+      });
+    } catch (ex) {
+      messenger.postMessage({
+        type: "ANNOTATION_RENDERER_FAILED_TO_INITIALIZE",
+      });
+    }
   });

--- a/packages/android/source-webview-scripts/annotation-renderer/index.mjs
+++ b/packages/android/source-webview-scripts/annotation-renderer/index.mjs
@@ -17,7 +17,7 @@ const HIGHLIGHT_CLASS_NAME = "literal-highlight";
 
 // Initial parameters set during script injection. Note that effective values may change over the
 // course of script execution due to message handling.
-const ANNOTATIONS = process.env.PARAM_ANNOTATIONS;
+const ANNOTATIONS = JSON.parse(process.env.PARAM_ANNOTATIONS);
 const FOCUSED_ANNOTATION_ID = process.env.PARAM_FOCUSED_ANNOTATION_ID;
 
 const messenger = new Messenger({
@@ -62,7 +62,14 @@ export default () =>
     storageSet("hasInitialized", true);
 
     try {
-      await renderer.render(ANNOTATIONS);
+      const rangeByAnnotationId = await renderer.render(ANNOTATIONS);
+      if (Object.values(rangeByAnnotationId).length !== ANNOTATIONS.length) {
+        messenger.postMessage({
+          type: "ANNOTATION_RENDERER_FAILED_TO_INITIALIZE",
+        });
+        return;
+      }
+
       renderer.onInitialAnnotationsRendered();
       annotationFocusManager.onAnnotationsRendered({
         annotations: ANNOTATIONS,

--- a/packages/android/source-webview-scripts/annotation-renderer/messenger.mjs
+++ b/packages/android/source-webview-scripts/annotation-renderer/messenger.mjs
@@ -36,6 +36,7 @@ export class Messenger {
       this.eventQueue.push(ev);
       return;
     }
+    console.log("[Literal] postMessage: " + JSON.stringify(ev))
     window.literalMessagePort.postMessage(JSON.stringify(ev));
   }
 

--- a/packages/android/source-webview-scripts/annotation-renderer/renderer.mjs
+++ b/packages/android/source-webview-scripts/annotation-renderer/renderer.mjs
@@ -15,7 +15,7 @@ const waitForXPath = (value) => {
         return false;
       }
     },
-    { interval: 50, timeout: 10 * 1000 }
+    { interval: 50, timeout: 5 * 1000 }
   ).then(() => evaluateXPath(value));
 };
 

--- a/packages/android/source-webview-scripts/annotation-renderer/renderer.mjs
+++ b/packages/android/source-webview-scripts/annotation-renderer/renderer.mjs
@@ -109,6 +109,8 @@ export class Renderer {
           console.error("[Literal] Unable to highlight range.", range, e);
         }
       });
+
+      return storageGet("annotationRanges");
     });
   }
 }

--- a/packages/android/source-webview-scripts/get-annotation-bounding-box/index.mjs
+++ b/packages/android/source-webview-scripts/get-annotation-bounding-box/index.mjs
@@ -5,7 +5,7 @@ import {
   get as storageGet,
   initialize as storageInitialize,
 } from "../shared/storage.mjs";
-const ANNOTATION = process.env.PARAM_ANNOTATION;
+const ANNOTATION = JSON.parse(process.env.PARAM_ANNOTATION);
 
 export default () => {
   storageInitialize();

--- a/packages/android/source-webview-scripts/get-annotation/model.mjs
+++ b/packages/android/source-webview-scripts/get-annotation/model.mjs
@@ -11,7 +11,7 @@ export const makeXPathSelectorFromRange = ({
   endPosition,
 }) => ({
   type: "XPATH_SELECTOR",
-  value: xPath(container),
+  value: xPath(container, true),
   refinedBy: [
     {
       type: "TEXT_POSITION_SELECTOR",


### PR DESCRIPTION
Improves the rendering of annotations within web archives.

### Added
- Added functionality to disable JavaScript within web archives.
- Added instrumentation around annotation renderer initialization events.
### Changed
- Various improvements to the ability to render web archive annotations. Use "optimized" xpath selectors for annotations to improve resilience, fallback to an index document with JavaScript disabled if we're unable to render annotations.

Closes: #119, #120 